### PR TITLE
Feature: add complaint status

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,4 +14,5 @@ model Complaint {
   email         String
   message       String
   createdAt     DateTime @default(now())
+  status        String   @default("unresolved")
 }

--- a/src/app/admin/complaints/page.tsx
+++ b/src/app/admin/complaints/page.tsx
@@ -8,6 +8,7 @@ interface Complaint {
   department: string;
   email: string;
   message: string;
+  status: string;
   createdAt: string;
 }
 
@@ -39,6 +40,32 @@ export default function AdminComplaintsPage() {
     fetchComplaints();
   }, []);
 
+  const resolveComplaint = async (id: number) => {
+    try {
+      await fetch(`/api/complaints/${id}/resolve`, {
+        method: 'PUT',
+      });
+      setComplaints((prev) =>
+        prev.map((complaint) =>
+          complaint.id === id ? { ...complaint, status: 'resolved' } : complaint
+        )
+      );
+    } catch (err) {
+      console.error('Failed to resolve complaint', err);
+    }
+  };
+
+  const deleteComplaint = async (id: number) => {
+    try {
+      await fetch(`/api/complaints/${id}`, {
+        method: 'DELETE',
+      });
+      setComplaints((prev) => prev.filter((complaint) => complaint.id !== id));
+    } catch (err) {
+      console.error('Failed to delete complaint', err);
+    }
+  };
+
   if (loading) {
     return <p className="text-white">Loading complaints...</p>;
   }
@@ -58,13 +85,14 @@ export default function AdminComplaintsPage() {
               <th className="px-6 py-4">Department</th>
               <th className="px-6 py-4">Email</th>
               <th className="px-6 py-4">Message</th>
-              <th className="px-6 py-4">Submitted At</th>
+              <th className="px-6 py-4">Status</th>  {/* New column for status */}
+              <th className="px-6 py-4">Actions</th>  {/* New column for actions */}
             </tr>
           </thead>
           <tbody>
             {complaints.length === 0 ? (
               <tr>
-                <td colSpan={5} className="text-center py-4">
+                <td colSpan={6} className="text-center py-4">
                   No complaints available.
                 </td>
               </tr>
@@ -77,8 +105,22 @@ export default function AdminComplaintsPage() {
                   <td className="px-6 py-4 max-w-xs overflow-hidden overflow-ellipsis whitespace-pre-wrap">
                     {complaint.message}
                   </td>
-                  <td className="px-6 py-4">
-                    {new Date(complaint.createdAt).toLocaleString()}
+                  <td className="px-6 py-4">{complaint.status}</td>  {/* Display complaint status */}
+                  <td className="px-6 py-4 flex space-x-2">
+                    {complaint.status === 'unresolved' && (
+                      <button
+                        onClick={() => resolveComplaint(complaint.id)}
+                        className="bg-blue-500 hover:bg-blue-700 text-white px-4 py-2 rounded-lg"
+                      >
+                        Mark as Resolved
+                      </button>
+                    )}
+                    <button
+                      onClick={() => deleteComplaint(complaint.id)}
+                      className="bg-red-500 hover:bg-red-700 text-white px-4 py-2 rounded-lg"
+                    >
+                      Delete
+                    </button>
                   </td>
                 </tr>
               ))

--- a/src/app/api/complaints/[id]/resolve/route.ts
+++ b/src/app/api/complaints/[id]/resolve/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+    const complaintId = parseInt(params.id, 10);
+    try {
+      const updatedComplaint = await prisma.complaint.update({
+        where: { id: complaintId },
+        data: { status: 'resolved' }, // Set status to resolved
+      });
+
+      return NextResponse.json(updatedComplaint, { status: 200 });
+    } catch (error) {
+      return NextResponse.json({ error: 'Failed to update complaint' }, { status: 500 });
+    }
+  }

--- a/src/app/api/complaints/[id]/route.ts
+++ b/src/app/api/complaints/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const complaintId = parseInt(params.id, 10);
+  try {
+    await prisma.complaint.delete({
+      where: { id: complaintId },
+    });
+    return NextResponse.json({ message: 'Complaint deleted successfully' }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to delete complaint' }, { status: 500 });
+  }
+}

--- a/src/app/api/complaints/route.ts
+++ b/src/app/api/complaints/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: NextRequest) {
     const { name, department, email, message, status } = await req.json();
 
     const complaint = await prisma.complaint.create({
-      data: { name, department, email, message, status: "unresolved", },
+      data: { name, department, email, message, status: "unresolved" },
     });
 
     return NextResponse.json(complaint, { status: 201 });

--- a/src/app/api/complaints/route.ts
+++ b/src/app/api/complaints/route.ts
@@ -5,10 +5,10 @@ const prisma = new PrismaClient();
 
 export async function POST(req: NextRequest) {
   try {
-    const { name, department, email, message } = await req.json();
+    const { name, department, email, message, status } = await req.json();
 
     const complaint = await prisma.complaint.create({
-      data: { name, department, email, message },
+      data: { name, department, email, message, status: "unresolved", },
     });
 
     return NextResponse.json(complaint, { status: 201 });


### PR DESCRIPTION
This pull request introduces the following changes to the complaints system:

1. **Added a `status` field to the `complaint` model in Prisma**:
   - The `status` field tracks the resolution state of complaints and is set to `unresolved` by default.
   - This enables easier management and filtering of complaints in the admin panel (e.g., marking complaints as "resolved").

2. **Database migration**:
   - Updated the database schema by adding the `status` field to the `complaint` model.
   - Ran the necessary Prisma migration to apply these changes to the database.

3. **Updated the API routes**:
   - The `POST` route now automatically sets the `status` of new complaints to `unresolved`.
   - Added new API endpoints to update complaint status (`/resolve`) and delete complaints.

### Changes:
- Prisma schema (`prisma/schema.prisma`) updated to add the `status` field.
- Updated API route logic to handle the `status` field for new and existing complaints.

